### PR TITLE
add include guard for header files to prevent `redefined type`

### DIFF
--- a/MikuMikuFormats/EncodingHelper.h
+++ b/MikuMikuFormats/EncodingHelper.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <locale.h>
 #include <stdio.h>
 #include <string>

--- a/MikuMikuFormats/Pmd.h
+++ b/MikuMikuFormats/Pmd.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <vector>
 #include <string>
 #include <memory>

--- a/MikuMikuFormats/Pmx.h
+++ b/MikuMikuFormats/Pmx.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <vector>
 #include <string>
 #include <iostream>

--- a/MikuMikuFormats/Vmd.h
+++ b/MikuMikuFormats/Vmd.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <vector>
 #include <string>
 #include <memory>


### PR DESCRIPTION
tested in VS2015
